### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/Sources/Keccak-fTrailCoreInKernelAtC.cpp
+++ b/Sources/Keccak-fTrailCoreInKernelAtC.cpp
@@ -45,7 +45,6 @@ TrailCoreInKernelAtC::TrailCoreInKernelAtC(const vector<SliceValue>& backgroundA
         CoreInfo workCoreInfo;
 
         workCoreInfo.hammingWeightAtA = 0;
-        workCoreInfo.hammingWeightAtA = 0;
         workCoreInfo.nrActiveRowsAtA = 0;
 
         workCoreInfo.stateAtB.assign(laneSize,0);

--- a/Sources/Keccak-fTrailExtension.cpp
+++ b/Sources/Keccak-fTrailExtension.cpp
@@ -167,14 +167,8 @@ KeccakFTrailExtension::KeccakFTrailExtension(const KeccakFDCLC& aParent, KeccakF
         }
     }
     else if (parent.getWidth() == 200) {
-        if (aDCorLC == KeccakFPropagation::DC) {
-            knownBounds.excludeBelowWeight(3, 20);
-            knownBounds.excludeBelowWeight(4, 46);
-        }
-        else {
-            knownBounds.excludeBelowWeight(3, 20);
-            knownBounds.excludeBelowWeight(4, 46);
-        }
+        knownBounds.excludeBelowWeight(3, 20);
+        knownBounds.excludeBelowWeight(4, 46);
     }
     else if (parent.getWidth() == 1600) {
         if (aDCorLC == KeccakFPropagation::DC) {


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V519](https://www.viva64.com/en/w/v519/) The 'workCoreInfo.hammingWeightAtA' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 47, 48. keccak-ftrailcoreinkernelatc.cpp 48
[V523](https://www.viva64.com/en/w/v523/) The 'then' statement is equivalent to the 'else' statement. keccak-ftrailextension.cpp 174